### PR TITLE
feat: add thumbnail preset and increase upload limits

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -7,7 +7,7 @@ QuickCrop is designed as a real-time photo cropping tool with live preview. Here
 ### 1. Upload an Image
 - Use the **left panel** to upload an image via drag-and-drop or file selection
 - Supported formats: JPEG, PNG, WebP
-- Maximum file size: 10MB (configurable)
+- Maximum file size: 50MB (configurable)
 
 ### 2. Crop Editor (Left Side)
 The **Crop Editor** on the left side is where you:

--- a/backend/api/endpoints/process.py
+++ b/backend/api/endpoints/process.py
@@ -78,6 +78,7 @@ async def generate_preview(
     preset_map = {
         'headshot': PresetType.HEADSHOT,
         'avatar': PresetType.AVATAR,
+        'thumbnail': PresetType.THUMBNAIL,
         'website': PresetType.WEBSITE,
         'full_body': PresetType.FULL_BODY
     }
@@ -161,6 +162,7 @@ async def export_image(
         preset_map = {
             'headshot': PresetType.HEADSHOT,
             'avatar': PresetType.AVATAR,
+            'thumbnail': PresetType.THUMBNAIL,
             'website': PresetType.WEBSITE,
             'full_body': PresetType.FULL_BODY
         }
@@ -229,6 +231,7 @@ async def export_image(
         preset_map = {
             'headshot': PresetType.HEADSHOT,
             'avatar': PresetType.AVATAR,
+            'thumbnail': PresetType.THUMBNAIL,
             'website': PresetType.WEBSITE,
             'full_body': PresetType.FULL_BODY
         }
@@ -348,6 +351,7 @@ async def validate_adjustments(
     preset_map = {
         'headshot': PresetType.HEADSHOT,
         'avatar': PresetType.AVATAR,
+        'thumbnail': PresetType.THUMBNAIL,
         'website': PresetType.WEBSITE,
         'full_body': PresetType.FULL_BODY
     }

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
     CORS_ORIGINS: List[str] = ["http://localhost:3000", "http://localhost:8000"]
     
     # File Upload Settings
-    MAX_UPLOAD_SIZE: int = 10 * 1024 * 1024  # 10MB
+    MAX_UPLOAD_SIZE: int = 50 * 1024 * 1024  # 50MB
     ALLOWED_EXTENSIONS: List[str] = [".jpg", ".jpeg", ".png", ".webp"]
     
     # Image Processing Settings
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     OUTPUT_DIR: str = "./outputs"
     
     # MediaPipe Settings
-    MIN_DETECTION_CONFIDENCE: float = 0.5
+    MIN_DETECTION_CONFIDENCE: float = 0.75
     MIN_TRACKING_CONFIDENCE: float = 0.5
     
     # Optimization Settings

--- a/backend/models/process.py
+++ b/backend/models/process.py
@@ -11,6 +11,7 @@ class CropPreset(str, Enum):
     """Available crop presets"""
     HEADSHOT = "headshot"  # 2000x2000 square
     AVATAR = "avatar"  # 300x300 square
+    THUMBNAIL = "thumbnail"  # 500x500 square
     WEBSITE = "website"  # 1600x2000 portrait (4:5)
     FULL_BODY = "full_body"  # 3400x4000 portrait (17:20)
 
@@ -75,6 +76,11 @@ PRESET_CONFIGS = {
     CropPreset.AVATAR: CropSettings(
         aspect_ratio=(1, 1),
         padding_percent=0.15,
+        focus_area="face"
+    ),
+    CropPreset.THUMBNAIL: CropSettings(
+        aspect_ratio=(1, 1),
+        padding_percent=0.2,
         focus_area="face"
     ),
     CropPreset.WEBSITE: CropSettings(

--- a/backend/services/crop_calculator.py
+++ b/backend/services/crop_calculator.py
@@ -297,6 +297,7 @@ class CropCalculatorFactory:
     _calculators = {
         PresetType.HEADSHOT: HeadshotCropCalculator,
         PresetType.AVATAR: HeadshotCropCalculator,  # Same as headshot
+        PresetType.THUMBNAIL: HeadshotCropCalculator,  # Same framing as headshot
         PresetType.WEBSITE: WebsiteCropCalculator,
         PresetType.FULL_BODY: FullBodyCropCalculator
     }

--- a/backend/services/presets.py
+++ b/backend/services/presets.py
@@ -12,6 +12,7 @@ class PresetType(Enum):
     """Enumeration of available crop preset types."""
     HEADSHOT = "headshot"
     AVATAR = "avatar"
+    THUMBNAIL = "thumbnail"
     WEBSITE = "website"
     FULL_BODY = "full_body"
 
@@ -75,6 +76,19 @@ PRESETS: Dict[PresetType, PresetConfig] = {
         margin_top=0.08,  # Same as headshot
         margin_sides=0.1,  # Same as headshot
         description="Small square crop for profile pictures and avatars"
+    ),
+
+    PresetType.THUMBNAIL: PresetConfig(
+        name="Thumbnail",
+        type=PresetType.THUMBNAIL,
+        output_width=500,
+        output_height=500,
+        aspect_ratio=1.0,
+        crop_ratio=(1, 1),
+        face_position="center",
+        margin_top=0.08,  # Same tuning as headshot/avatar for consistency
+        margin_sides=0.1,
+        description="Medium square crop for internal directories and thumbnails"
     ),
     
     PresetType.WEBSITE: PresetConfig(

--- a/backend/tests/test_crop_calculator.py
+++ b/backend/tests/test_crop_calculator.py
@@ -182,6 +182,9 @@ class TestCropCalculatorFactory(unittest.TestCase):
         
         avatar_calc = CropCalculatorFactory.create(PresetType.AVATAR)
         self.assertIsInstance(avatar_calc, HeadshotCropCalculator)
+
+        thumbnail_calc = CropCalculatorFactory.create(PresetType.THUMBNAIL)
+        self.assertIsInstance(thumbnail_calc, HeadshotCropCalculator)
         
         website_calc = CropCalculatorFactory.create(PresetType.WEBSITE)
         self.assertIsInstance(website_calc, WebsiteCropCalculator)
@@ -202,20 +205,26 @@ class TestCropCalculationFunctions(unittest.TestCase):
         """Test single crop calculation."""
         face = FaceBox(x=400, y=300, width=200, height=250)
         crop = calculate_crop(PresetType.HEADSHOT, face, 2000, 2000)
-        
+
         self.assertIsInstance(crop, CropBox)
         self.assertEqual(crop.preset_type, PresetType.HEADSHOT)
         self.assertEqual(crop.width, crop.height)  # Square for headshot
+
+        thumb_crop = calculate_crop(PresetType.THUMBNAIL, face, 2000, 2000)
+        self.assertIsInstance(thumb_crop, CropBox)
+        self.assertEqual(thumb_crop.preset_type, PresetType.THUMBNAIL)
+        self.assertEqual(thumb_crop.width, thumb_crop.height)
     
     def test_calculate_all_crops(self):
         """Test calculating all crop types at once."""
         face = FaceBox(x=400, y=300, width=200, height=250)
         crops = calculate_all_crops(face, 3000, 4000)
-        
+
         # Should have all preset types
         self.assertEqual(len(crops), len(PresetType))
         self.assertIn(PresetType.HEADSHOT, crops)
         self.assertIn(PresetType.AVATAR, crops)
+        self.assertIn(PresetType.THUMBNAIL, crops)
         self.assertIn(PresetType.WEBSITE, crops)
         self.assertIn(PresetType.FULL_BODY, crops)
         

--- a/backend/tests/test_crop_processor.py
+++ b/backend/tests/test_crop_processor.py
@@ -173,6 +173,17 @@ class TestImageProcessor(unittest.TestCase):
         img = Image.open(io.BytesIO(result))
         self.assertEqual(img.format, 'PNG')
         self.assertEqual(img.size, (300, 300))  # Avatar dimensions
+
+    def test_process_thumbnail_preset(self):
+        """Test processing the 500x500 thumbnail preset."""
+        result = self.processor.process_preset(
+            PresetType.THUMBNAIL,
+            self.face,
+            format='JPEG'
+        )
+
+        img = Image.open(io.BytesIO(result))
+        self.assertEqual(img.size, (500, 500))
     
     def test_process_with_adjustment(self):
         """Test processing with manual adjustment."""

--- a/backend/tests/test_presets.py
+++ b/backend/tests/test_presets.py
@@ -15,9 +15,10 @@ class TestPresetConfiguration(unittest.TestCase):
     
     def test_preset_types_exist(self):
         """Test that all preset types are defined."""
-        self.assertEqual(len(PresetType), 4)
+        self.assertEqual(len(PresetType), 5)
         self.assertIn(PresetType.HEADSHOT, PresetType)
         self.assertIn(PresetType.AVATAR, PresetType)
+        self.assertIn(PresetType.THUMBNAIL, PresetType)
         self.assertIn(PresetType.WEBSITE, PresetType)
         self.assertIn(PresetType.FULL_BODY, PresetType)
     
@@ -28,7 +29,10 @@ class TestPresetConfiguration(unittest.TestCase):
         
         avatar = get_preset(PresetType.AVATAR)
         self.assertEqual(avatar.dimensions, (300, 300))
-        
+
+        thumbnail = get_preset(PresetType.THUMBNAIL)
+        self.assertEqual(thumbnail.dimensions, (500, 500))
+
         website = get_preset(PresetType.WEBSITE)
         self.assertEqual(website.dimensions, (1600, 2000))
         
@@ -42,7 +46,10 @@ class TestPresetConfiguration(unittest.TestCase):
         
         avatar = get_preset(PresetType.AVATAR)
         self.assertAlmostEqual(avatar.aspect_ratio, 1.0, places=2)
-        
+
+        thumbnail = get_preset(PresetType.THUMBNAIL)
+        self.assertAlmostEqual(thumbnail.aspect_ratio, 1.0, places=2)
+
         website = get_preset(PresetType.WEBSITE)
         self.assertAlmostEqual(website.aspect_ratio, 0.8, places=2)
         
@@ -54,7 +61,11 @@ class TestPresetConfiguration(unittest.TestCase):
         headshot = get_preset(PresetType.HEADSHOT)
         self.assertEqual(headshot.margin_top, 0.08)
         self.assertEqual(headshot.margin_sides, 0.1)
-        
+
+        thumbnail = get_preset(PresetType.THUMBNAIL)
+        self.assertEqual(thumbnail.margin_top, 0.08)
+        self.assertEqual(thumbnail.margin_sides, 0.1)
+
         website = get_preset(PresetType.WEBSITE)
         self.assertEqual(website.margin_top, 0.05)
         self.assertEqual(website.margin_sides, 0.08)
@@ -67,7 +78,10 @@ class TestPresetConfiguration(unittest.TestCase):
         """Test face position settings."""
         headshot = get_preset(PresetType.HEADSHOT)
         self.assertEqual(headshot.face_position, "center")
-        
+
+        thumbnail = get_preset(PresetType.THUMBNAIL)
+        self.assertEqual(thumbnail.face_position, "center")
+
         website = get_preset(PresetType.WEBSITE)
         self.assertEqual(website.face_position, "upper")
         
@@ -100,9 +114,10 @@ class TestPresetConfiguration(unittest.TestCase):
     def test_get_all_presets(self):
         """Test getting all presets."""
         all_presets = get_all_presets()
-        self.assertEqual(len(all_presets), 4)
+        self.assertEqual(len(all_presets), 5)
         self.assertIn(PresetType.HEADSHOT, all_presets)
         self.assertIn(PresetType.AVATAR, all_presets)
+        self.assertIn(PresetType.THUMBNAIL, all_presets)
         self.assertIn(PresetType.WEBSITE, all_presets)
         self.assertIn(PresetType.FULL_BODY, all_presets)
     
@@ -124,6 +139,10 @@ class TestPresetConfiguration(unittest.TestCase):
         self.assertEqual(
             get_preset_by_dimensions(300, 300),
             PresetType.AVATAR
+        )
+        self.assertEqual(
+            get_preset_by_dimensions(500, 500),
+            PresetType.THUMBNAIL
         )
         self.assertEqual(
             get_preset_by_dimensions(1600, 2000),

--- a/frontend/components/CropEditor.tsx
+++ b/frontend/components/CropEditor.tsx
@@ -17,6 +17,7 @@ interface CropEditorProps {
   onCroppingStateChange?: (isCropping: boolean) => void;
   presets?: CropPresetConfig[];
   category?: PhotoCategory; // 'employee' | 'project'
+  onCategoryChange?: (category: PhotoCategory) => void;
 }
 
 interface CropState {
@@ -46,10 +47,16 @@ export default function CropEditor({
   cropArea,
   onCroppingStateChange,
   presets = CROP_PRESETS,
-  category
+  category,
+  onCategoryChange
 }: CropEditorProps) {
   // Find the current preset configuration
   const currentPresetConfig = presets.find(p => p.id === preset);
+  const resolvedCategory: PhotoCategory = category || 'employee';
+  const categoryOptions: Array<{ value: PhotoCategory; label: string }> = [
+    { value: 'employee', label: 'Team' },
+    { value: 'project', label: 'Project' }
+  ];
   const aspectRatio = currentPresetConfig 
     ? currentPresetConfig.aspectRatio[0] / currentPresetConfig.aspectRatio[1]
     : 1;
@@ -666,11 +673,44 @@ export default function CropEditor({
 
   return (
     <div className="card">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-semibold flex items-center gap-2">
-          <Crop className="w-5 h-5" />
-          Crop Settings
-        </h2>
+      <div className="flex justify-between items-center mb-4 gap-3">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold flex items-center gap-2">
+            <Crop className="w-5 h-5" />
+            Crop Settings
+          </h2>
+          {onCategoryChange && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs uppercase tracking-wide text-gray-400 hidden sm:inline">Mode</span>
+              <div className="flex bg-gray-800 border border-gray-700 rounded-full p-0.5" role="group" aria-label="Photo category">
+                {categoryOptions.map(option => {
+                  const isActive = resolvedCategory === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => {
+                        if (!isActive) {
+                          onCategoryChange(option.value);
+                        }
+                      }}
+                      className={`px-2 py-1 text-xs font-medium rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+                        isActive
+                          ? 'bg-orange-500 text-white shadow-sm'
+                          : 'text-gray-300 hover:text-white'
+                      }`}
+                      aria-pressed={isActive}
+                      aria-label={`Switch to ${option.label.toLowerCase()} mode`}
+                      title={`Use ${option.label} presets`}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
         <div className="flex gap-1">
           <button
             onClick={undo}

--- a/frontend/components/ImageUploader.tsx
+++ b/frontend/components/ImageUploader.tsx
@@ -22,7 +22,7 @@ export default function ImageUploader({ onUpload, isProcessing = false }: ImageU
     if (rejectedFiles.length > 0) {
       const rejection = rejectedFiles[0];
       if (rejection.errors[0]?.code === 'file-too-large') {
-        setUploadError('File size must be less than 10MB');
+        setUploadError('File size must be less than 50MB');
       } else if (rejection.errors[0]?.code === 'file-invalid-type') {
         setUploadError('Please upload a valid image file (JPEG, PNG, or WebP)');
       } else {
@@ -86,7 +86,7 @@ export default function ImageUploader({ onUpload, isProcessing = false }: ImageU
       'image/webp': ['.webp']
     },
     maxFiles: 1,
-    maxSize: 10 * 1024 * 1024, // 10MB
+    maxSize: 50 * 1024 * 1024, // 50MB
     disabled: isProcessing || uploadProgress > 0,
     noClick: false,
     noKeyboard: false
@@ -190,7 +190,7 @@ export default function ImageUploader({ onUpload, isProcessing = false }: ImageU
                   Drag & drop an image here, or click to select
                 </p>
                 <p className="text-sm text-gray-400">
-                  Supports: JPEG, PNG, WebP (max 10MB, min 500x500px)
+                  Supports: JPEG, PNG, WebP (max 50MB, min 500x500px)
                 </p>
                 <button
                   type="button"

--- a/frontend/tests/components/CropEditor.test.tsx
+++ b/frontend/tests/components/CropEditor.test.tsx
@@ -171,6 +171,25 @@ describe('CropEditor', () => {
     expect(screen.getByText('Redo →')).toBeInTheDocument();
   });
 
+  it('renders category toggle when override handler provided', () => {
+    const onCategoryChange = jest.fn();
+
+    render(
+      <CropEditor
+        file={mockFile}
+        preset="square"
+        onPresetChange={mockOnPresetChange}
+        category="employee"
+        onCategoryChange={onCategoryChange}
+      />
+    );
+
+    const projectButton = screen.getByRole('button', { name: /switch to project mode/i });
+    fireEvent.click(projectButton);
+
+    expect(onCategoryChange).toHaveBeenCalledWith('project');
+  });
+
   it('displays keyboard shortcuts help', () => {
     render(
       <CropEditor

--- a/frontend/tests/components/ImageUploader.test.tsx
+++ b/frontend/tests/components/ImageUploader.test.tsx
@@ -72,7 +72,7 @@ describe('ImageUploader', () => {
     dropHandler([], rejectedFiles);
     
     await waitFor(() => {
-      expect(screen.getByText('File size must be less than 10MB')).toBeInTheDocument();
+      expect(screen.getByText('File size must be less than 50MB')).toBeInTheDocument();
     });
   });
 

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -12,6 +12,7 @@ export type PresetId =
 export type ExportSize =
   | 'headshot'
   | 'avatar'
+  | 'thumbnail'
   | 'website'
   | 'full_body'
   | 'proj_banner'
@@ -73,7 +74,8 @@ export const EMPLOYEE_PRESETS: CropPresetConfig[] = [
     aspectRatio: [1, 1],
     outputSizes: [
       { id: 'headshot', name: 'Headshot', size: [2000, 2000] },
-      { id: 'avatar', name: 'Avatar', size: [300, 300] }
+      { id: 'avatar', name: 'Avatar', size: [300, 300] },
+      { id: 'thumbnail', name: 'Thumbnail', size: [500, 500] }
     ],
     description: 'Square crop for professional headshots and avatars'
   },


### PR DESCRIPTION
## Summary\n- add THUMBNAIL preset across backend models, calculators, and API mappings with accompanying tests\n- raise upload size limit to 50MB, update MediaPipe detection confidence, and sync UI copy/docs\n- support manual employee/project overrides with a locked toggle in the crop editor and type updates\n\n## Testing\n- [ ] backend: pytest -q\n- [ ] frontend: npm test